### PR TITLE
feat/backend-options

### DIFF
--- a/lib/cozy_proxy.ex
+++ b/lib/cozy_proxy.ex
@@ -198,7 +198,7 @@ defmodule CozyProxy do
   alias CozyProxy.Dispatcher
 
   def start_link(init_arg) do
-    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+    Supervisor.start_link(__MODULE__, init_arg)
   end
 
   @impl true

--- a/lib/cozy_proxy.ex
+++ b/lib/cozy_proxy.ex
@@ -106,6 +106,13 @@ defmodule CozyProxy do
         * `"/admin"`
         * `"/api"`
         * ...
+    * `:rewrite_path_info`:
+      * optional
+      * typespec: `boolean()`
+      * default: `true`
+      * examples:
+        * `true`
+        * `false`
 
   ### The order of backends matters
 

--- a/lib/cozy_proxy.ex
+++ b/lib/cozy_proxy.ex
@@ -95,7 +95,7 @@ defmodule CozyProxy do
         * ...
     * `:host`:
       * optional
-      * typespec: `String.t()`
+      * typespec: `String.t()` | `Regex.t()`
       * examples:
         * `"example.com"`
         * ...

--- a/lib/cozy_proxy/backend.ex
+++ b/lib/cozy_proxy/backend.ex
@@ -5,7 +5,8 @@ defmodule CozyProxy.Backend do
             method: :unset,
             host: :unset,
             path: :unset,
-            path_info: :unset
+            path_info: :unset,
+            rewrite_path_info: true
 
   @type t :: %__MODULE__{}
 

--- a/lib/cozy_proxy/dispatcher.ex
+++ b/lib/cozy_proxy/dispatcher.ex
@@ -49,10 +49,6 @@ defmodule CozyProxy.Dispatcher do
   defp check_path(conn, %Backend{path_info: path_info}),
     do: {conn, List.starts_with?(conn.path_info, path_info)}
 
-  defp dispatch(conn, %Backend{plug: {mod, opts}, path_info: :unset}) do
-    mod.call(conn, opts)
-  end
-
   # Inspired by `Plug.forward/4`
   defp dispatch(conn, %Backend{
          plug: {mod, opts},
@@ -77,6 +73,10 @@ defmodule CozyProxy.Dispatcher do
       | path_info: path_info,
         script_name: script_name
     }
+  end
+
+  defp dispatch(conn, %Backend{plug: {mod, opts}}) do
+    mod.call(conn, opts)
   end
 
   defp rewrite_path_info(conn, path_info_prefix) do

--- a/lib/cozy_proxy/dispatcher.ex
+++ b/lib/cozy_proxy/dispatcher.ex
@@ -54,7 +54,11 @@ defmodule CozyProxy.Dispatcher do
   end
 
   # Inspired by `Plug.forward/4`
-  defp dispatch(conn, %Backend{plug: {mod, opts}, path_info: path_info_prefix})
+  defp dispatch(conn, %Backend{
+         plug: {mod, opts},
+         path_info: path_info_prefix,
+         rewrite_path_info: true
+       })
        when is_list(path_info_prefix) do
     %{
       path_info: path_info,

--- a/test/cozy_proxy/dispatcher_test.exs
+++ b/test/cozy_proxy/dispatcher_test.exs
@@ -81,6 +81,34 @@ defmodule CozyProxy.DispatcherTest do
     end
   end
 
+  describe "Path rewriting" do
+    test "is enabled by default" do
+      backends = [
+        Backend.new!(plug: SamplePlug.EchoPath, path: "/api")
+      ]
+
+      conn = conn(:post, "/api/v1")
+      conn = dispatch(conn, backends)
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert conn.resp_body == "/v1"
+    end
+
+    test "can be disabled" do
+      backends = [
+        Backend.new!(plug: SamplePlug.EchoPath, path: "/api", rewrite_path_info: false)
+      ]
+
+      conn = conn(:post, "/api/v1")
+      conn = dispatch(conn, backends)
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert conn.resp_body == "/api/v1"
+    end
+  end
+
   describe "Respond with" do
     test "General Plug is supported" do
       backends = [

--- a/test/cozy_proxy/dispatcher_test.exs
+++ b/test/cozy_proxy/dispatcher_test.exs
@@ -62,6 +62,19 @@ defmodule CozyProxy.DispatcherTest do
       assert conn.resp_body == "Plug: Hello, World!"
     end
 
+    test "by matching host via regex is supported" do
+      backends = [
+        Backend.new!(plug: SamplePlug.General, host: ~r/^test/)
+      ]
+
+      conn = conn(:post, "https://test.example.com/")
+      conn = dispatch(conn, backends)
+
+      assert conn.state == :sent
+      assert conn.status == 200
+      assert conn.resp_body == "Plug: Hello, World!"
+    end
+
     test "by matching path is supported" do
       backends = [
         Backend.new!(plug: SamplePlug.General, path: "/api")

--- a/test/support/sample_plug/echo_path.ex
+++ b/test/support/sample_plug/echo_path.ex
@@ -1,0 +1,25 @@
+defmodule SamplePlug.EchoPath do
+  @moduledoc """
+  A plug that echos the path info from conn.
+
+  ## How to start the server?
+
+      webserver = {Bandit, plug: SamplePlug.EchoPath, scheme: :http, port: 4000}
+      {:ok, _} = Supervisor.start_link([webserver], strategy: :one_for_one)
+
+  """
+
+  import Plug.Conn
+
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(%Plug.Conn{path_info: path_info} = conn, _opts) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(200, "/" <> Enum.join(path_info, "/"))
+  end
+end


### PR DESCRIPTION
Includes some new functionality:

- Optionally disable path info rewriting
- Match hosts based on regex

A bug fix:

- Remove name from `start_link`
  Adding a name allows the GenServer to be looked up by its name, however it prevents the user from spawning multiple GenServers with the same name. This prevents a user from starting two versions of CozyProxy (i.e. one for HTTP and one for HTTPS). There are no consequences for this change right now since the GenServer is never looked up by name. Should this change in the future a [custom registry](https://hexdocs.pm/elixir/Registry.html#module-using-in-via) can be used.

As well it includes a dev container configuration to enable containerized development.